### PR TITLE
Threadsafe reloading rules

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -1,24 +1,12 @@
 package com.lyft.data.gateway.ha.router;
 
-import java.io.FileReader;
-import java.util.HashMap;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
-import org.jeasy.rules.api.Facts;
-import org.jeasy.rules.api.Rules;
-import org.jeasy.rules.api.RulesEngine;
-import org.jeasy.rules.core.DefaultRulesEngine;
-import org.jeasy.rules.mvel.MVELRuleFactory;
-import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
 
 /** RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group. */
 public interface RoutingGroupSelector {
   String ROUTING_GROUP_HEADER = "X-Trino-Routing-Group";
   String ALTERNATE_ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
-
-  @Slf4j
-  final class Logger {}
 
   /**
    * Routing group selector that relies on the X-Trino-Routing-Group or X-Presto-Routing-Group
@@ -34,26 +22,7 @@ public interface RoutingGroupSelector {
    * to determine the right routing group.
    */
   static RoutingGroupSelector byRoutingRulesEngine(String rulesConfigPath) {
-    RulesEngine rulesEngine = new DefaultRulesEngine();
-    MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
-
-    return request -> {
-      try {
-        Rules rules = ruleFactory.createRules(
-            new FileReader(rulesConfigPath));
-        Facts facts = new Facts();
-        HashMap<String, String> result = new HashMap<String, String>();
-        facts.put("request", request);
-        facts.put("result", result);
-        rulesEngine.fire(rules, facts);
-        return result.get("routingGroup");
-      } catch (Exception e) {
-        Logger.log.error("Error opening rules configuration file,"
-            + " using routing group header as default.", e);
-        return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
-          .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
-      }
-    };
+    return new RuleReloadingRoutingGroupSelector(rulesConfigPath);
   }
 
   /**

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RuleReloadingRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RuleReloadingRoutingGroupSelector.java
@@ -1,0 +1,76 @@
+package com.lyft.data.gateway.ha.router;
+
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jeasy.rules.api.Facts;
+import org.jeasy.rules.api.Rules;
+import org.jeasy.rules.api.RulesEngine;
+import org.jeasy.rules.core.DefaultRulesEngine;
+import org.jeasy.rules.mvel.MVELRuleFactory;
+import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
+
+@Slf4j
+public class RuleReloadingRoutingGroupSelector
+    implements RoutingGroupSelector  {
+
+  RulesEngine rulesEngine = new DefaultRulesEngine();
+  MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
+  String rulesConfigPath;
+  Rules rules = new Rules();
+  long lastUpdatedTime;
+
+  RuleReloadingRoutingGroupSelector(String rulesConfigPath) {
+    this.rulesConfigPath = rulesConfigPath;
+    try {
+      rules = ruleFactory.createRules(
+              new FileReader(rulesConfigPath));
+      BasicFileAttributes attr = Files.readAttributes(Path.of(rulesConfigPath),
+              BasicFileAttributes.class);
+      lastUpdatedTime = attr.lastModifiedTime().toMillis();
+
+    } catch (Exception e) {
+      log.error("Error opening rules configuration file, using "
+              + "routing group header as default.", e);
+    }
+  }
+
+  @Override
+  public String findRoutingGroup(HttpServletRequest request) {
+    try {
+      BasicFileAttributes attr = Files.readAttributes(Path.of(rulesConfigPath),
+              BasicFileAttributes.class);
+      log.debug(String.format("Current modified time %s, last modified time %s",
+              attr.lastModifiedTime().toMillis(), lastUpdatedTime));
+      if (attr.lastModifiedTime().toMillis() > lastUpdatedTime) {
+        log.info(String.format("Updating rules to file modified at %s", attr.lastModifiedTime()));
+        synchronized (this) {
+          rules = ruleFactory.createRules(
+                  new FileReader(rulesConfigPath));
+          lastUpdatedTime = attr.lastModifiedTime().toMillis();
+        }
+      }
+      Facts facts = new Facts();
+      HashMap<String, String> result = new HashMap<String, String>();
+      facts.put("request", request);
+      facts.put("result", result);
+      rulesEngine.fire(rules, facts);
+      return result.get("routingGroup");
+
+    } catch (Exception e) {
+      log.error("Error opening rules configuration file, using "
+              + "routing group header as default.", e);
+      // Invalid rules could lead to perf problems as every thread goes into the synchronized
+      // block until the issue is resolved
+    }
+    return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
+        .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
+  }
+}


### PR DESCRIPTION
Currently the routing configuration yaml file is parsed and routing rules are recreated every time a request is received. This causes errors because the parsing is done by `snakeyaml`, which is not threadsafe.

This PR 
* Loads the routing config at startup
* checks to see if the file has changed when a request is received, and only reloads if there is a change
* synchronizes the reload