### PR TITLE
Will/insights

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
@@ -19,4 +19,8 @@ public class RequestRouterConfiguration {
 
   // Use the certificate between gateway and presto?
   private boolean forwardKeystore;
+
+  // attempt to lookup unknown query Ids if true, otherwise rely
+  // on recording them in the DB
+  private boolean lookupQueryIds = true;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -13,12 +13,14 @@ import com.lyft.data.proxyserver.wrapper.MultiReadHttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Enumeration;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.HttpMethod;
@@ -37,6 +39,9 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String UI_API_STATS_PATH = "/ui/api/stats";
   public static final String UI_API_QUEUED_LIST_PATH = "/ui/api/query?state=QUEUED";
   public static final String PRESTO_UI_PATH = "/ui";
+  public static final String OAUTH2_PATH = "/oauth2";
+
+  public static final String INSIGHTS_STATEMENT_PATH = "/ui/api/insights/ide/statement";
   public static final String USER_HEADER = "X-Trino-User";
   public static final String ALTERNATE_USER_HEADER = "X-Presto-User";
   public static final String SOURCE_HEADER = "X-Trino-Source";
@@ -56,6 +61,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   private final Meter requestMeter;
   private final int serverApplicationPort;
 
+  private final Map<Integer, String> requestIdBackendMap = new HashMap<>();
+
   public QueryIdCachingProxyHandler(
       QueryHistoryManager queryHistoryManager,
       RoutingManager routingManager,
@@ -71,6 +78,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
 
   @Override
   public void preConnectionHook(HttpServletRequest request, Request proxyRequest) {
+    log.debug("Enter pre conection hook");
     if (request.getMethod().equals(HttpMethod.POST)
         && request.getRequestURI().startsWith(V1_STATEMENT_PATH)) {
       requestMeter.mark();
@@ -89,7 +97,6 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     if (isPathWhiteListed(request.getRequestURI())) {
       setForwardedHostHeaderOnProxyRequest(request, proxyRequest);
     }
-
   }
 
   private boolean isPathWhiteListed(String path) {
@@ -97,7 +104,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         || path.startsWith(V1_QUERY_PATH)
         || path.startsWith(PRESTO_UI_PATH)
         || path.startsWith(V1_INFO_PATH)
-        || path.startsWith(UI_API_STATS_PATH);
+        || path.startsWith(UI_API_STATS_PATH)
+        || path.startsWith(OAUTH2_PATH);
   }
 
   public boolean isAuthEnabled() {
@@ -109,31 +117,43 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   }
 
   @Override
-  public String rewriteTarget(HttpServletRequest request) {
+  public boolean isKnownSessionId(String sessionId) {
+    return !Strings.isNullOrEmpty(routingManager.findBackendForUiCookie(sessionId));
+  }
+
+  public boolean deleteUiCookie(String sessionId) {
+    return routingManager.deleteUiCookie(sessionId);
+  }
+
+  @Override
+  public String rewriteTarget(HttpServletRequest request, int requestId) {
+    log.debug("Enter rewriteTarget");
     /* Here comes the load balancer / gateway */
     String backendAddress = "http://localhost:" + serverApplicationPort;
-
-    // Only load balance presto query APIs.
+    // Only load balance presto query and ui APIs.
     if (isPathWhiteListed(request.getRequestURI())) {
       String queryId = extractQueryIdIfPresent(request);
-
-      // Find query id and get url from cache
       if (!Strings.isNullOrEmpty(queryId)) {
         backendAddress = routingManager.findBackendForQueryId(queryId);
-      } else {
-        String routingGroup = routingGroupSelector.findRoutingGroup(request);
-        String user = Optional.ofNullable(request.getHeader(USER_HEADER))
-                .orElse(request.getHeader(ALTERNATE_USER_HEADER));
-        if (!Strings.isNullOrEmpty(routingGroup)) {
-          // This falls back on adhoc backend if there are no cluster found for the routing group.
-          backendAddress = routingManager.provideBackendForRoutingGroup(routingGroup, user);
-        } else {
-          backendAddress = routingManager.provideAdhocBackend(user);
+      } else if (doRecordQueryId(request)) {
+        backendAddress = getBackendForRequest(request);
+        log.debug("mapping " + requestId + " to " + backendAddress);
+        requestIdBackendMap.put(requestId, backendAddress);
+      } else if (!Strings.isNullOrEmpty(request.getRequestedSessionId())) {
+        //pin browser sessions to the same backend based on jsessionid, but load balance queries
+        backendAddress = routingManager.findBackendForUiCookie(
+                request.getRequestedSessionId().split("\\.")[0]);
+        if (Strings.isNullOrEmpty(backendAddress)) {
+          log.error("Unknown session id: " + request.getRequestedSessionId());
+          backendAddress = getBackendForRequest(request);
         }
+      } else {
+        backendAddress = getBackendForRequest(request);
+        routingManager.setBackendForUiCookie(request.getSession().getId(), backendAddress);
+        log.debug("using session id " + request.getSession().getId());
       }
-      // set target backend so that we could save queryId to backend mapping later.
-      ((MultiReadHttpServletRequest) request).addHeader(PROXY_TARGET_HEADER, backendAddress);
     }
+
     if (isAuthEnabled() && request.getHeader("Authorization") != null) {
       if (!handleAuthRequest(request)) {
         // This implies the AuthRequest was not authenticated, hence we error out from here.
@@ -141,22 +161,34 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         return null;
       }
     }
+
     String targetLocation =
-        backendAddress
-            + request.getRequestURI()
-            + (request.getQueryString() != null ? "?" + request.getQueryString() : "");
+            backendAddress
+                    + request.getRequestURI()
+                    + (request.getQueryString() != null ? "?" + request.getQueryString() : "");
 
     String originalLocation =
-        request.getScheme()
-            + "://"
-            + request.getRemoteHost()
-            + ":"
-            + request.getServerPort()
-            + request.getRequestURI()
-            + (request.getQueryString() != null ? "?" + request.getQueryString() : "");
-
+            request.getScheme()
+                    + "://"
+                    + request.getRemoteHost()
+                    + ":"
+                    + request.getServerPort()
+                    + request.getRequestURI()
+                    + (request.getQueryString() != null ? "?" + request.getQueryString() : "");
     log.info("Rerouting [{}]--> [{}]", originalLocation, targetLocation);
     return targetLocation;
+  }
+
+  String getBackendForRequest(HttpServletRequest request) {
+    String routingGroup = routingGroupSelector.findRoutingGroup(request);
+    String user = Optional.ofNullable(request.getHeader(USER_HEADER))
+            .orElse(request.getHeader(ALTERNATE_USER_HEADER));
+    if (!Strings.isNullOrEmpty(routingGroup)) {
+      // This falls back on adhoc backend if there are no cluster found for the routing group.
+      return routingManager.provideBackendForRoutingGroup(routingGroup, user);
+    } else {
+      return routingManager.provideAdhocBackend(user);
+    }
   }
 
   protected String extractQueryIdIfPresent(HttpServletRequest request) {
@@ -216,59 +248,86 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     return queryId;
   }
 
+  private boolean doRecordQueryId(HttpServletRequest request) {
+    String requestPath = request.getRequestURI();
+    return (requestPath.startsWith(V1_STATEMENT_PATH)
+            || requestPath.startsWith(INSIGHTS_STATEMENT_PATH))
+            && request.getMethod().equals(HttpMethod.POST);
+  }
+
   protected void postConnectionHook(
       HttpServletRequest request,
       HttpServletResponse response,
       byte[] buffer,
       int offset,
       int length,
-      Callback callback) {
+      Callback callback,
+      int requestId) {
+    log.debug("Enter post conection hook");
+    log.debug("URI: " + request.getRequestURI());
     try {
-      String requestPath = request.getRequestURI();
-      if (requestPath.startsWith(V1_STATEMENT_PATH)
-          && request.getMethod().equals(HttpMethod.POST)) {
-        String output;
-        boolean isGZipEncoding = isGZipEncoding(response);
-        if (isGZipEncoding) {
-          output = plainTextFromGz(buffer);
-        } else {
-          output = new String(buffer);
-        }
-        log.debug("For Request [{}] got Response output [{}]", request.getRequestURI(), output);
-
-        QueryHistoryManager.QueryDetail queryDetail = getQueryDetailsFromRequest(request);
-        log.debug("Extracting Proxy destination : [{}] for request : [{}]",
-            queryDetail.getBackendUrl(), request.getRequestURI());
-
-        if (response.getStatus() == HttpStatus.OK_200) {
-          HashMap<String, String> results = OBJECT_MAPPER.readValue(output, HashMap.class);
-          queryDetail.setQueryId(results.get("id"));
-
-          if (!Strings.isNullOrEmpty(queryDetail.getQueryId())) {
-            routingManager.setBackendForQueryId(
-                queryDetail.getQueryId(), queryDetail.getBackendUrl());
-            log.debug(
-                "QueryId [{}] mapped with proxy [{}]",
-                queryDetail.getQueryId(),
-                queryDetail.getBackendUrl());
-          } else {
-            log.debug("QueryId [{}] could not be cached", queryDetail.getQueryId());
-          }
-        } else {
-          log.error(
-              "Non OK HTTP Status code with response [{}] , Status code [{}]",
-              output,
-              response.getStatus());
-        }
-        // Saving history at gateway.
-        queryHistoryManager.submitQueryDetail(queryDetail);
+      if (doRecordQueryId(request)) {
+        recordBackendForQueryId(request, response, buffer, requestId);
       } else {
-        log.debug("SKIPPING For {}", requestPath);
+        log.debug("SKIPPING For {}", request.getRequestURI());
       }
     } catch (Exception e) {
       log.error("Error in proxying falling back to super call", e);
     }
     super.postConnectionHook(request, response, buffer, offset, length, callback);
+  }
+
+  void recordBackendForQueryId(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      byte[] buffer,
+      int requestId)
+      throws IOException {
+    String output;
+    boolean isGZipEncoding = isGZipEncoding(response);
+    if (isGZipEncoding) {
+      output = plainTextFromGz(buffer);
+    } else {
+      output = new String(buffer);
+    }
+    log.debug("For Request [{}] got Response output [{}]", request.getRequestURI(), output);
+    log.debug("Request Id: " + requestId);
+
+    QueryHistoryManager.QueryDetail queryDetail = getQueryDetailsFromRequest(request);
+    String backendUrl = Strings.isNullOrEmpty(queryDetail.getBackendUrl())
+            ? requestIdBackendMap.get(requestId)
+            : queryDetail.getBackendUrl();
+    if (backendUrl == null) {
+      log.warn("request id not found in "
+              + Arrays.toString(requestIdBackendMap.keySet().toArray()));
+    }
+    log.debug("Extracting Proxy destination : [{}] for request : [{}]",
+            backendUrl, request.getRequestURI());
+
+    if (response.getStatus() == HttpStatus.OK_200) {
+      HashMap<String, String> results = OBJECT_MAPPER.readValue(output, HashMap.class);
+      queryDetail.setQueryId(results.get("id"));
+
+      if (!Strings.isNullOrEmpty(queryDetail.getQueryId())) {
+        //TODO: use the DB to back the queryId cache so it is shared across gateway instances
+        routingManager.setBackendForQueryId(
+                queryDetail.getQueryId(), backendUrl);
+        log.debug(
+                "QueryId [{}] mapped with proxy [{}]",
+                queryDetail.getQueryId(),
+                backendUrl);
+        requestIdBackendMap.remove(requestId);
+      } else {
+        log.debug("QueryId [{}] could not be cached", queryDetail.getQueryId());
+      }
+    } else {
+      log.error(
+              "Non OK HTTP Status code with response [{}] , Status code [{}]",
+              output,
+              response.getStatus());
+    }
+    // Saving history at gateway.
+    queryHistoryManager.submitQueryDetail(queryDetail);
   }
 
   static void setForwardedHostHeaderOnProxyRequest(HttpServletRequest request,

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -37,6 +37,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String UI_API_STATS_PATH = "/ui/api/stats";
   public static final String UI_API_QUEUED_LIST_PATH = "/ui/api/query?state=QUEUED";
   public static final String PRESTO_UI_PATH = "/ui";
+  public static final String OAUTH2_PATH = "/oauth2";
   public static final String USER_HEADER = "X-Trino-User";
   public static final String ALTERNATE_USER_HEADER = "X-Presto-User";
   public static final String SOURCE_HEADER = "X-Trino-Source";
@@ -96,6 +97,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     return path.startsWith(V1_STATEMENT_PATH)
         || path.startsWith(V1_QUERY_PATH)
         || path.startsWith(PRESTO_UI_PATH)
+        || path.startsWith(OAUTH2_PATH)
         || path.startsWith(V1_INFO_PATH)
         || path.startsWith(UI_API_STATS_PATH);
   }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -9,6 +9,7 @@ import com.lyft.data.gateway.ha.config.RequestRouterConfiguration;
 import com.lyft.data.gateway.ha.config.RoutingRulesConfiguration;
 import com.lyft.data.gateway.ha.handler.QueryIdCachingProxyHandler;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import com.lyft.data.gateway.ha.router.CacheManager;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.HaGatewayManager;
 import com.lyft.data.gateway.ha.router.HaQueryHistoryManager;
@@ -30,6 +31,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   private final QueryHistoryManager queryHistoryManager;
   private final RoutingManager routingManager;
   private final JdbcConnectionManager connectionManager;
+  private final CacheManager cacheManager;
 
   public HaGatewayProviderModule(HaGatewayConfiguration configuration, Environment environment) {
     super(configuration, environment);
@@ -37,8 +39,12 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
     resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
     gatewayBackendManager = new HaGatewayManager(connectionManager);
     queryHistoryManager = new HaQueryHistoryManager(connectionManager);
+    cacheManager = new CacheManager(connectionManager);
     routingManager =
-        new HaRoutingManager(gatewayBackendManager, (HaQueryHistoryManager) queryHistoryManager);
+        new HaRoutingManager(gatewayBackendManager,
+                queryHistoryManager,
+                cacheManager,
+                configuration.getRequestRouter().isLookupQueryIds());
   }
 
   protected ProxyHandler getProxyHandler() {

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/QueryIdBackend.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/QueryIdBackend.java
@@ -1,0 +1,21 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@IdName("queryid")
+@Table("queryid")
+public class QueryIdBackend extends Model {
+  public static final String queryid = "queryid";
+  public static final String backend = "backend";
+
+  public static void create(
+      QueryIdBackend model,
+      String queryid,
+      String backend) {
+    model.set(QueryIdBackend.queryid, queryid);
+    model.set(QueryIdBackend.backend, backend);
+    model.insert();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/UiRequestBackend.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/UiRequestBackend.java
@@ -1,0 +1,23 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import org.javalite.activejdbc.Model;
+//import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@IdName("ui_cookie")
+@Table("ui_request")
+//@Cached
+public class UiRequestBackend extends Model {
+  public static final String uiCookie = "ui_cookie";
+  public static final String backend = "backend";
+
+  public static void create(
+      UiRequestBackend model,
+      String uiCookie,
+      String backend) {
+    model.set(UiRequestBackend.uiCookie, uiCookie);
+    model.set(UiRequestBackend.backend, backend);
+    model.insert();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/CacheManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/CacheManager.java
@@ -1,0 +1,82 @@
+package com.lyft.data.gateway.ha.router;
+
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import com.lyft.data.gateway.ha.persistence.dao.QueryIdBackend;
+import com.lyft.data.gateway.ha.persistence.dao.UiRequestBackend;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+public class CacheManager {
+  private JdbcConnectionManager connectionManager;
+
+  public CacheManager(JdbcConnectionManager connectionManager) {
+    this.connectionManager = connectionManager;
+  }
+  
+  public void submitUiBackend(String uiCookie, String backend) {
+    try {
+      connectionManager.open();
+      UiRequestBackend dao = new UiRequestBackend();
+      log.debug(String.format("Writing cookie %s for backend %s", uiCookie, backend));
+      UiRequestBackend.create(dao, uiCookie, backend);
+    } catch (Exception e) {
+      log.warn(String.format("Error saving cookie %s for backend %s: %s", uiCookie, backend, e));
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  public void submitQueryIdBackend(String queryId, String backend) {
+    try {
+      connectionManager.open();
+      QueryIdBackend dao = new QueryIdBackend();
+      log.debug(String.format("Writing queryId %s for backend %s", queryId, backend));
+      QueryIdBackend.create(dao, queryId, backend);
+    } catch (Exception e) {
+      log.warn(String.format("Error saving queryId %s for backend %s: %s", queryId, backend, e));
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  public String getBackendForUiCookie(String uiCookie) {
+    try {
+      connectionManager.open();
+      UiRequestBackend uiRequestBackend = UiRequestBackend.findById(uiCookie);
+      return (String) uiRequestBackend.get(UiRequestBackend.backend);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  public String getBackendForQueryId(String queryId) {
+    try {
+      connectionManager.open();
+      QueryIdBackend queryIdBackend = QueryIdBackend.findById(queryId);
+      return (String) queryIdBackend.get(QueryIdBackend.backend);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  public boolean removeUiCookie(String uiCookie) {
+    try {
+      connectionManager.open();
+      UiRequestBackend uiRequestBackend = UiRequestBackend.findById(uiCookie);
+      return uiRequestBackend.delete();
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  public boolean removeQueryId(String queryId) {
+    try {
+      connectionManager.open();
+      QueryIdBackend queryIdBackend = QueryIdBackend.findById(queryId);
+      return queryIdBackend.delete();
+    } finally {
+      connectionManager.close();
+    }
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
@@ -8,9 +8,19 @@ public class HaRoutingManager extends RoutingManager {
   QueryHistoryManager queryHistoryManager;
 
   public HaRoutingManager(
-      GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager) {
-    super(gatewayBackendManager);
+      GatewayBackendManager gatewayBackendManager,
+          QueryHistoryManager queryHistoryManager,
+          CacheManager cacheManager,
+          boolean lookupQueryIds) {
+    super(gatewayBackendManager, cacheManager, lookupQueryIds);
     this.queryHistoryManager = queryHistoryManager;
+  }
+
+  public HaRoutingManager(
+          GatewayBackendManager gatewayBackendManager,
+          QueryHistoryManager queryHistoryManager,
+          CacheManager cacheManager) {
+    this(gatewayBackendManager, queryHistoryManager, cacheManager, true);
   }
 
   @Override

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -46,8 +46,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
    * Presto cluster queue length and falls back to Running Count if queue length are equal.
    */
   public PrestoQueueLengthRoutingTable(GatewayBackendManager gatewayBackendManager,
-                                       QueryHistoryManager queryHistoryManager) {
-    super(gatewayBackendManager, queryHistoryManager);
+          QueryHistoryManager queryHistoryManager, CacheManager cacheManager) {
+    super(gatewayBackendManager, queryHistoryManager, cacheManager);
     routingGroupWeightSum = new ConcurrentHashMap<String, Integer>();
     clusterQueueLengthMap = new ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>>();
     weightedDistributionRouting = new HashMap<String, TreeMap<Integer, String>>();

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -76,3 +76,13 @@ CREATE TABLE IF NOT EXISTS exact_match_source_selectors (
     PRIMARY KEY (environment, source, query_type),
     UNIQUE (source, environment, query_type, resource_group_id)
 );
+
+CREATE TABLE IF NOT EXISTS ui_request (
+    ui_cookie VARCHAR(256) NOT NULL PRIMARY KEY,
+    backend VARCHAR(256)
+);
+
+CREATE TABLE IF NOT EXISTS queryid (
+    queryid VARCHAR(256) NOT NULL PRIMARY KEY,
+    backend VARCHAR(256)
+)

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaSingleBackend.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaSingleBackend.java
@@ -34,6 +34,8 @@ public class TestGatewayHaSingleBackend {
     // Now populate the backend
     HaGatewayTestUtils.setUpBackend(
         "presto1", "http://localhost:" + backendPort, "externalUrl", true, "adhoc", routerPort);
+    System.out.println(String.format("Backend setup with routerPort %s and backendPort %s",
+            routerPort, backendPort));
   }
 
   @Test
@@ -46,7 +48,7 @@ public class TestGatewayHaSingleBackend {
             .post(requestBody)
             .build();
     Response response = httpClient.newCall(request).execute();
-    Assert.assertEquals(EXPECTED_RESPONSE, response.body().string());
+    Assert.assertEquals(response.body().string(), EXPECTED_RESPONSE);
   }
 
   @AfterClass(alwaysRun = true)

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -27,6 +27,7 @@ public class TestPrestoQueueLengthRoutingTable {
   PrestoQueueLengthRoutingTable routingTable;
   GatewayBackendManager backendManager;
   QueryHistoryManager historyManager;
+  CacheManager cacheManager;
   String[] mockRoutingGroups = {"adhoc", "scheduled"};
   String mockRoutingGroup = "adhoc";
 
@@ -48,7 +49,8 @@ public class TestPrestoQueueLengthRoutingTable {
     backendManager = new HaGatewayManager(connectionManager);
     historyManager = new HaQueryHistoryManager(connectionManager) {
     };
-    routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
+    cacheManager = new CacheManager(connectionManager);
+    routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager, cacheManager);
 
     for (String grp : mockRoutingGroups) {
       addMockBackends(grp, NUM_BACKENDS, 0);

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyHandler.java
@@ -27,6 +27,12 @@ public class ProxyHandler {
     return null;
   }
 
+  protected String rewriteTarget(HttpServletRequest request, int requestId) {
+    // Dont override this unless absolutely needed.
+    return null;
+  }
+
+
   /**
    * Request interceptor.
    *
@@ -54,6 +60,22 @@ public class ProxyHandler {
       int offset,
       int length,
       Callback callback) {
+    try {
+      response.getOutputStream().write(buffer, offset, length);
+      callback.succeeded();
+    } catch (Throwable var9) {
+      callback.failed(var9);
+    }
+  }
+
+  protected void postConnectionHook(
+          HttpServletRequest request,
+          HttpServletResponse response,
+          byte[] buffer,
+          int offset,
+          int length,
+          Callback callback,
+          int requestId) {
     try {
       response.getOutputStream().write(buffer, offset, length);
       callback.succeeded();
@@ -128,5 +150,9 @@ public class ProxyHandler {
   protected boolean isCompressed(final byte[] compressed) {
     return (compressed[0] == (byte) (GZIPInputStream.GZIP_MAGIC))
         && (compressed[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
+  }
+
+  public boolean isKnownSessionId(String sessionId) {
+    return false;
   }
 }


### PR DESCRIPTION
Pin UI sessions to a backend. This allows the UI OAuth handshake to work properly. It may be possible to relax this condition in the future and only pin during the handshake. 

Additionally, store query IDs in a backend DB table so that a search across backends isn't required.