### PR TITLE
Add timestamps to queryid and cookie tables to allow purging old records

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/QueryIdBackend.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/QueryIdBackend.java
@@ -1,14 +1,17 @@
 package com.lyft.data.gateway.ha.persistence.dao;
 
 import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.Cached;
 import org.javalite.activejdbc.annotations.IdName;
 import org.javalite.activejdbc.annotations.Table;
 
 @IdName("queryid")
 @Table("queryid")
+@Cached
 public class QueryIdBackend extends Model {
   public static final String queryid = "queryid";
   public static final String backend = "backend";
+  public static final String createdTimestamp = "created_timestamp";
 
   public static void create(
       QueryIdBackend model,
@@ -16,6 +19,7 @@ public class QueryIdBackend extends Model {
       String backend) {
     model.set(QueryIdBackend.queryid, queryid);
     model.set(QueryIdBackend.backend, backend);
+    model.set(QueryIdBackend.createdTimestamp, System.currentTimeMillis());
     model.insert();
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/UiRequestBackend.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/UiRequestBackend.java
@@ -1,16 +1,17 @@
 package com.lyft.data.gateway.ha.persistence.dao;
 
 import org.javalite.activejdbc.Model;
-//import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.Cached;
 import org.javalite.activejdbc.annotations.IdName;
 import org.javalite.activejdbc.annotations.Table;
 
 @IdName("ui_cookie")
 @Table("ui_request")
-//@Cached
+@Cached
 public class UiRequestBackend extends Model {
   public static final String uiCookie = "ui_cookie";
   public static final String backend = "backend";
+  public static final String createdTimestamp = "created_timestamp";
 
   public static void create(
       UiRequestBackend model,
@@ -18,6 +19,7 @@ public class UiRequestBackend extends Model {
       String backend) {
     model.set(UiRequestBackend.uiCookie, uiCookie);
     model.set(UiRequestBackend.backend, backend);
+    model.set(UiRequestBackend.createdTimestamp, System.currentTimeMillis());
     model.insert();
   }
 }

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -79,10 +79,12 @@ CREATE TABLE IF NOT EXISTS exact_match_source_selectors (
 
 CREATE TABLE IF NOT EXISTS ui_request (
     ui_cookie VARCHAR(256) NOT NULL PRIMARY KEY,
-    backend VARCHAR(256)
+    backend VARCHAR(256),
+    created_timestamp BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS queryid (
     queryid VARCHAR(256) NOT NULL PRIMARY KEY,
-    backend VARCHAR(256)
+    backend VARCHAR(256),
+    created_timestamp BIGINT
 )


### PR DESCRIPTION
Since we now store query IDs in a DB, we need a way to clean them up. This PR adds timestamps so that we can decide which ones are safe to delete.