### PR TITLE
Will/no app redirect

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RequestRouterConfiguration.java
@@ -19,4 +19,8 @@ public class RequestRouterConfiguration {
 
   // Use the certificate between gateway and presto?
   private boolean forwardKeystore;
+
+  // By default non-whitelisted requests are rerouted to the application port.
+  // Set this to false to if separate networking rules are required  
+  private boolean rerouteRequestsToApplication = true;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -145,6 +145,11 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         return null;
       }
     }
+    
+    if (Strings.isNullOrEmpty(backendAddress)) {
+      log.debug("No backend assigned for " + request);
+      return null;
+    }
     String targetLocation =
         backendAddress
             + request.getRequestURI()

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -55,18 +55,21 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
 
   private final Meter requestMeter;
   private final int serverApplicationPort;
+  private final boolean rerouteRequestsToApplication;
 
   public QueryIdCachingProxyHandler(
       QueryHistoryManager queryHistoryManager,
       RoutingManager routingManager,
       RoutingGroupSelector routingGroupSelector,
       int serverApplicationPort,
-      Meter requestMeter) {
+      Meter requestMeter,
+      boolean rerouteRequestsToApplication) {
     this.requestMeter = requestMeter;
     this.routingManager = routingManager;
     this.routingGroupSelector = routingGroupSelector;
     this.queryHistoryManager = queryHistoryManager;
     this.serverApplicationPort = serverApplicationPort;
+    this.rerouteRequestsToApplication = rerouteRequestsToApplication;
   }
 
   @Override
@@ -111,7 +114,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   @Override
   public String rewriteTarget(HttpServletRequest request) {
     /* Here comes the load balancer / gateway */
-    String backendAddress = "http://localhost:" + serverApplicationPort;
+    String backendAddress =
+            rerouteRequestsToApplication ? "http://localhost:" + serverApplicationPort : null;
 
     // Only load balance presto query APIs.
     if (isPathWhiteListed(request.getRequestURI())) {

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -155,7 +155,6 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
       } else {
         backendAddress = getBackendForRequest(request);
         routingManager.setBackendForUiCookie(request.getSession().getId(), backendAddress);
-        log.debug("using session id " + request.getSession().getId());
       }
     }
 
@@ -168,7 +167,6 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     }
     
     if (Strings.isNullOrEmpty(backendAddress)) {
-      log.debug("No backend assigned for " + request);
       return null;
     }
     String targetLocation =

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -61,7 +61,8 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
         getRoutingManager(),
         routingGroupSelector,
         getApplicationPort(),
-        requestMeter);
+        requestMeter,
+        getConfiguration().getRequestRouter().isRerouteRequestsToApplication());
   }
 
   @Provides

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java
@@ -56,6 +56,15 @@ public class ProxyServletImpl extends ProxyServlet.Transparent {
     return httpClient;
   }
 
+
+  @Override
+  protected void onProxyRewriteFailed(
+          HttpServletRequest clientRequest,
+          HttpServletResponse proxyResponse) {
+    // Will be called if rewriteTarget returns null
+    super.sendProxyResponseError(clientRequest, proxyResponse, 404);
+  }
+
   /** Customize the headers of forwarding proxy requests. */
   @Override
   protected void addProxyHeaders(HttpServletRequest request, Request proxyRequest) {
@@ -70,8 +79,7 @@ public class ProxyServletImpl extends ProxyServlet.Transparent {
     String target = null;
     if (proxyHandler != null) {
       target = proxyHandler.rewriteTarget(request, this.getRequestId(request));
-    }
-    if (target == null) {
+    } else {
       target = super.rewriteTarget(request);
     }
     log.debug("Target : " + target);

--- a/proxyserver/src/test/java/com/lyft/data/proxyserver/TestProxyServer.java
+++ b/proxyserver/src/test/java/com/lyft/data/proxyserver/TestProxyServer.java
@@ -30,7 +30,9 @@ public class TestProxyServer {
 
     int serverPort = backendPort + 1;
     ProxyServerConfiguration config = buildConfig(backend.getUrl("/").toString(), serverPort);
-    ProxyServer proxyServer = new ProxyServer(config, new ProxyHandler());
+    ProxyServer proxyServer = new ProxyServer(config, null);
+    // Passing a null proxyHandler will cause ProxyServletImpl to defer to
+    // super.rewriteTarget, which is the desired behavior since ProxyHandler just returns a null.
 
     try {
       proxyServer.start();
@@ -55,12 +57,12 @@ public class TestProxyServer {
 
     int serverPort = backendPort + 1;
     ProxyServerConfiguration config = buildConfig(backend.getUrl("/").toString(), serverPort);
-    ProxyServer proxyServer = new ProxyServer(config, new ProxyHandler());
+    ProxyServer proxyServer = new ProxyServer(config, null);
 
     try {
       proxyServer.start();
       CloseableHttpClient httpclient = HttpClientBuilder.create().build();
-      HttpUriRequest httpUriRequest = new HttpGet("http://localhost:" + serverPort);
+      HttpUriRequest httpUriRequest = new HttpGet("http://localhost:" + serverPort + "/v1/statement");
       httpUriRequest.setHeader("HEADER1", "FOO");
       httpUriRequest.setHeader("HEADER2", "BAR");
 


### PR DESCRIPTION
By default, non whitelisted paths are redirected to the gateway's app endpoint. This is problematic from a security perspective, because it gives anyone with access to the request endpoint the ability to add or remove backends. This PR adds an option to not automatically redirect non whitelisted paths. This will currently result in a 500 error, as a follow up it would be nice to add a default 404 page.