### PR TITLE
support using / or bare hostname

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -105,7 +105,9 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         || path.startsWith(OAUTH2_PATH)
         || path.startsWith(V1_INFO_PATH)
         || path.startsWith(UI_API_STATS_PATH)
-        || path.startsWith(OAUTH2_PATH);
+        || path.startsWith(OAUTH2_PATH)
+        || path.equals("/")
+        || path.isEmpty(); // allow backends to redirect a bare hostname to /ui
   }
 
   public boolean isAuthEnabled() {


### PR DESCRIPTION
We need to let `/` and `''` through so that the backend can return a 303 to `/ui`